### PR TITLE
pass prop to change styling between different buttons

### DIFF
--- a/src/common/components/atoms/Button.js
+++ b/src/common/components/atoms/Button.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 const StyledButton = styled.button`
     display: inline-block;
@@ -19,15 +19,21 @@ const StyledButton = styled.button`
     background-color: #c40058;
     color: #fff;
 
+    ${({plain}) => plain && css`
+        border: none;
+        background-color: transparent;
+        color: #222;
+    `}
+
     &:hover, &:focus {
         background-color: transparent;
         color: #c40058;
     }
 `
 
-export const Button = ({onClick, label, ...rest}) => {
+export const Button = ({onClick, label, plain, ...rest}) => {
     return (
-        <StyledButton onClick={onClick} aria-pressed="false">
+        <StyledButton onClick={onClick} aria-pressed="false" plain={plain}>
             { label }
         </StyledButton>
     )
@@ -35,7 +41,8 @@ export const Button = ({onClick, label, ...rest}) => {
 
 Button.propTypes = {
     onClick: PropTypes.func,
-    label: PropTypes.string.isRequired
+    label: PropTypes.string.isRequired,
+    plain: PropTypes.bool,
 }
 
 Button.defaultProps = {

--- a/src/common/components/molecules/Header.js
+++ b/src/common/components/molecules/Header.js
@@ -19,7 +19,7 @@ export const Header = () => {
                 href="https://endy.com" 
                 img={endyLogo} />
             <h1>Happy Room Designer (Endy Edition)</h1>
-            <Button label="Instructions" />
+            <Button label="Instructions" plain />
         </StyledHeader>
     )
 }


### PR DESCRIPTION
## Pre-Review Checklist
- [x] Tested on modern browsers (latest Chrome, Firefox, Safari, Edge)
- [x] Audited with aXe (Prelim accessibility check)
- [o] No console warnings or errors
- [x] Provided author comments (I’ve gone through my code changes and provided any comments to help reviewers)

## What Changed & Why
- Passing prop called 'plain' to customize the styling for when the button component renders.
- The button in the header should look like as though it was an anchor link while the other button element retains the same styling as before.

## Screenshots

**Before**
<img width="1680" alt="Screen Shot 2021-09-27 at 12 05 41 PM" src="https://user-images.githubusercontent.com/58713256/134945154-7d2ff9fc-e21f-4a5b-8d65-a92760a09cfc.png">

**After**
<img width="1680" alt="Screen Shot 2021-09-27 at 12 06 55 PM" src="https://user-images.githubusercontent.com/58713256/134945221-de87848a-c34d-4698-b154-c14a9468594e.png">