### PR TITLE
rename header to be called nav

### DIFF
--- a/src/common/components/molecules/Nav.js
+++ b/src/common/components/molecules/Nav.js
@@ -3,7 +3,7 @@ import { Button, Anchor} from '../atoms'
 import endyLogo from '../../../assets/endy-logo.svg'
 import styled from 'styled-components';
 
-const StyledHeader = styled.header`
+const StyledNav = styled.nav`
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -12,14 +12,14 @@ const StyledHeader = styled.header`
     padding-right: 2rem;
 `
 
-export const Header = () => {
+export const Nav = () => {
     return (
-        <StyledHeader>
+        <StyledNav>
             <Anchor          
                 href="https://endy.com" 
                 img={endyLogo} />
             <h1>Happy Room Designer (Endy Edition)</h1>
             <Button label="Instructions" />
-        </StyledHeader>
+        </StyledNav>
     )
 }

--- a/src/common/components/molecules/index.js
+++ b/src/common/components/molecules/index.js
@@ -1,2 +1,2 @@
 export * from './Footer'
-export * from './Header'
+export * from './Nav'

--- a/src/common/components/molecules/index.js~504ce989c08ea9d796cc3173478445bb4ed73e96
+++ b/src/common/components/molecules/index.js~504ce989c08ea9d796cc3173478445bb4ed73e96
@@ -1,1 +1,0 @@
-export * from './Header'

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -1,13 +1,12 @@
 import './App.css';
 import { BrowserRouter as Router, Route, Link } from 'react-router-dom'
 import { Button, TextComponent, Anchor } from '../common/components/atoms'
-import { Header } from '../common/components/molecules'
-import { Footer } from '../common/components/molecules'
+import { Nav, Footer } from '../common/components/molecules'
 
 const App = () => {
   return (
     <div className="App">
-        <Header />
+        <Nav />
         <TextComponent />
         <Button label="Click me please!" />
         <Footer />


### PR DESCRIPTION
## Pre-Review Checklist
- [ ] Tested on modern browsers (latest Chrome, Firefox, Safari, Edge)
- [ ] Audited with aXe (Prelim accessibility check)
- [ ] No console warnings or errors
- [ ] Provided author comments (I’ve gone through my code changes and provided any comments to help reviewers)

## What Changed & Why
Renamed Header component to be called Nav component as it makes more sense since this element the top-level landmark of the page so changing it to be a navigation component/element is better semantics. 