### PR TITLE
pass plain prop to button component in nav

### DIFF
--- a/src/common/components/molecules/Nav.js
+++ b/src/common/components/molecules/Nav.js
@@ -19,7 +19,7 @@ export const Nav = () => {
                 href="https://endy.com" 
                 img={endyLogo} />
             <h1>Happy Room Designer (Endy Edition)</h1>
-            <Button label="Instructions" />
+            <Button label="Instructions" plain />
         </StyledNav>
     )
 }


### PR DESCRIPTION
## Pre-Review Checklist
- [ ] Tested on modern browsers (latest Chrome, Firefox, Safari, Edge)
- [ ] Audited with aXe (Prelim accessibility check)
- [x] No console warnings or errors
- [ ] Provided author comments (I’ve gone through my code changes and provided any comments to help reviewers)

## What Changed & Why
i forgot to pass the plain prop value to the button component living in the nav parent component so i added it in!
